### PR TITLE
Update Dockerfile to use node:24.8.0-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM node:24.3.0-alpine3.22 AS builder
+FROM node:24.8.0-alpine3.22 AS builder
 
 WORKDIR /usr/src/split-evaluator
 
@@ -8,7 +8,7 @@ COPY package.json package-lock.json ./
 RUN npm install --only=production
 
 # Runner stage
-FROM node:24.3.0-alpine3.22 AS runner
+FROM node:24.8.0-alpine3.22 AS runner
 
 WORKDIR /usr/src/split-evaluator
 


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?

The docker image has been updated to use node:24.8.0-alpine3.22, fixing some high vulnerabilities.

## How do we test the changes introduced in this PR?
Build the docker image and run the evaluator.

## Extra Notes
I've built this locally and tested it with a simple call to `client/get-treatment` with positive results.
